### PR TITLE
Added coloring for dashed-names and #{string interpolations}

### DIFF
--- a/livescript-mode.el
+++ b/livescript-mode.el
@@ -218,6 +218,8 @@ with LiveScript."
   :type 'hook
   :group 'livescript)
 
+(defvar working-on-file nil)
+
 (defvar livescript-mode-map
   (let ((map (make-sparse-keymap)))
     ;; key bindings
@@ -360,7 +362,7 @@ called `livescript-compiled-buffer-name'."
 (defvar livescript-prototype-regexp "\\(\\(\\w\\|\\.\\|_\\| \\|$\\)+?\\)::\\(\\(\\w\\|\\.\\|_\\| \\|$\\)+?\\):")
 
 ;; Assignment
-(defvar livescript-assign-regexp "\\(\\(\\w\\|\\.\\|_\\|$\\)+?\s*\\):")
+(defvar livescript-assign-regexp "\\(\\(\\w\\|\\.\\|_\\|$\\|-\\)+?\s*\\):")
 
 ;; Local Assignment
 (defvar livescript-local-assign-regexp "\\(\\(_\\|\\w\\|\\$\\)+\\)\s+=")
@@ -409,6 +411,7 @@ called `livescript-compiled-buffer-name'."
 			      livescript-cs-keywords
 			      iced-livescript-cs-keywords) 'words)))
 
+(defvar livescript-string-interpolation-regexp "#{[^}\n\\\\]*\\(?:\\\\.[^}\n\\\\]*\\)*}")
 
 ;; Create the list for font-lock. Each class of keyword is given a
 ;; particular face.
@@ -426,7 +429,8 @@ called `livescript-compiled-buffer-name'."
     (,livescript-regexp-regexp . font-lock-constant-face)
     (,livescript-boolean-regexp . font-lock-constant-face)
     (,livescript-lambda-regexp . (2 font-lock-function-name-face))
-    (,livescript-keywords-regexp 1 font-lock-keyword-face)))
+    (,livescript-keywords-regexp 1 font-lock-keyword-face)
+    (,livescript-string-interpolation-regexp 0 font-lock-constant-face t)))
 
 ;;
 ;; Helper Functions
@@ -837,11 +841,11 @@ END lie."
               (progn
                 (livescript-block-comment-delimiter match)
                 (goto-char match)
-                (next-line)
+                (forward-line)
                 (livescript-propertize-function (point) end))))))))
 
 ;;;###autoload
-(define-derived-mode livescript-mode fundamental-mode
+(define-derived-mode livescript-mode prog-mode
   "LiveScript"
   "Major mode for editing LiveScript."
 
@@ -881,7 +885,8 @@ END lie."
   (setq imenu-create-index-function 'livescript-imenu-create-index)
 
   ;; no tabs
-  (setq indent-tabs-mode nil))
+  (setq indent-tabs-mode nil)
+  (setq tab-width livescript-tab-width))
 
 ;;
 ;; Compile-on-Save minor mode


### PR DESCRIPTION
I recently started hacking in LiveScript - after a year or so of writing CoffeeScript - and I fell in love with it. I looked for LS support for Emacs. I found at least 4 modes, but they were rather primitive. This one is the most feature complete and so I'm using it now. I already wrote a few lines of code for it and I thought that maybe someone else than me would like to have them. So here is pull request. Besides what I wrote in the commit message, `livescript-mode.el` now compiles without warnings.

I'm somewhat disappointed that this mode is not maintained anymore (I read this on the Issues page). I'm not immediately interested in taking it over, but I probably will hack on it some more, so it would be great if you could find some time to review my pull requests and merge them if they're ok.
